### PR TITLE
:art: Standardise the Shade of Green

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -13,7 +13,7 @@ function createButtonClass(props: ButtonProps): string {
     "py-2 px-4 rounded-md",
     props.large && "md:text-xl md:py-3 md:px-5 md:rounded-lg",
     props.accent
-      ? "bg-green-500 hover:bg-green-600 text-white drop-shadow-md"
+      ? "bg-[#40b93c] hover:bg-green-600 text-white drop-shadow-md"
       : "bg-white hover:bg-gray-100 drop-shadow-lg",
     props.className
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,7 +32,7 @@
       }
 
       a {
-        @apply border-b font-bold text-green-500 hover:text-green-600 border-green-400 hover:border-green-600 no-underline;
+        @apply border-b font-bold text-[#40b93c] hover:text-green-600 border-green-400 hover:border-green-600 no-underline;
       }
     }
   }


### PR DESCRIPTION
The green utilised on the logos for sugarcity.io is #40b93c, so updated the green accents on the website to match this.